### PR TITLE
fixing title on the about us page ipad and iphone view

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -399,6 +399,8 @@ a:focus {
   background-clip: text;
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
 }
 
 .section-title .title span::-moz-ssselection {


### PR DESCRIPTION
## Rationale

Fixing title color on ipad and iphone users view.

## Advice for Reviewers & Testing Notes

I followed the requirements to use a clean CSS, the property box-decoration-break specifies how an element's fragments should be rendered.

## Screenshots:

- Add a screenshot or two of your changes, where applicable.

## Task Name

Ipad and Phone, landscape and portrait: the words “Eisteddfod Society” spacing issue. #114


## Linting Checklist
- [ x] No commented code
- [ x] Code Formatted nicely (Prettier)
- [ x] PR your own code before you assign reviewers