### PR TITLE
take out margin from the sentence

### DIFF
--- a/about.html
+++ b/about.html
@@ -244,7 +244,7 @@
                     is one of the reasons why this Eisteddfod has run for 70
                     years.
                   </p>
-                  <p class="mb-0 p-text">
+                  <p>
                     Essential to the smooth running and continuation of the
                     Eisteddfod are <strong>our wonderful volunteers</strong> who
                     come forward to assist with stage managing, scribing for


### PR DESCRIPTION
## Rationale

the text was misaligned.

## Advice for Reviewers & Testing Notes

Margin was set on this sentence, so I took it off.
I tested it applying zoom at the sentence.

## Screenshots:

before:
<img width="1440" alt="Screen Shot 2022-01-29 at 4 05 26 pm" src="https://user-images.githubusercontent.com/84433857/151650244-f05142f3-19cf-4684-bd26-bf27677c4c97.png">

now:

<img width="1440" alt="Screen Shot 2022-01-29 at 4 07 55 pm" src="https://user-images.githubusercontent.com/84433857/151650249-43e4d52f-9663-4622-bd84-b69b5a191dc3.png">


## Task Name

[issue #144 ](https://github.com/codesydney/eisteddfod/issues/144)


## Linting Checklist
- [ x] No commented code
- [ x] Code Formatted nicely (Prettier)
- [ ] PR your own code before you assign reviewers