### PR TITLE
added text info about arrows

### DIFF
--- a/index.html
+++ b/index.html
@@ -308,8 +308,9 @@
                               target="_blank"> Covid-19 Safety Plan
                             </a> which will be updated for the 2022 Eisteddfod in line with NSW Health Rules applying at
                             the time.
-
+                          
                           </p>
+                          <p>Click on the arrows for more important info.</p>
                         </div>
                       </div>
                       <div class="swiper-slide welcome-content">
@@ -329,6 +330,7 @@
                             <a href="volunteer.html">Volunteers</a> page for more information or Phone/SMS Elaine Hodda on 0409 604 076.
 
                           </p>
+                          <p>Click on the arrows for more important info.</p>
                         </div>
                       </div>
                       <div class="swiper-slide welcome-content">
@@ -366,8 +368,9 @@
                             <td>$38.00</td>
                           </tr>
                         </table>
+                        <p>Click on the arrows for more important info.</p>
                       </div>
-
+                      
                       <div class="swiper-slide welcome-content">
                         <div class="client-content">
                           <h1 class='title'>Venue for 2022</h1>


### PR DESCRIPTION
## Rationale

A text info was needed to the user be able to identify the arrows.

## Advice for Reviewers & Testing Notes

Added the text in the end of each "content".
Tested locally.

## Screenshots:

before:
<img width="1440" alt="Screen Shot 2022-01-29 at 7 51 25 pm" src="https://user-images.githubusercontent.com/84433857/151656387-8d308d71-ee04-48c6-a933-b18ebeb940f0.png">

now:
<img width="1440" alt="Screen Shot 2022-01-29 at 7 50 19 pm" src="https://user-images.githubusercontent.com/84433857/151656381-c9bfe751-0dd6-4fba-88a4-b53bb2d905a9.png">


## Task Name

[issue #154 ](https://github.com/codesydney/eisteddfod/issues/154)


## Linting Checklist
- [ x] No commented code
- [ x] Code Formatted nicely (Prettier)
- [ x] PR your own code before you assign reviewers